### PR TITLE
Configure Dependabot version updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates every week
+      interval: "weekly"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,7 +26,7 @@ jobs:
           architecture: x64
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9.7"
           architecture: x64

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Setup Java & Python
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -35,7 +35,7 @@ jobs:
 
       # ICAT Ansible clone and install dependencies
       - name: Checkout icat-ansible
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
@@ -84,7 +84,7 @@ jobs:
           asadmin undeploy `asadmin list-applications | grep authn.db | awk '{print $1;}'`
 
       - name: Checkout authn-db
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Payara must be sourced otherwise the Maven build command fails
       - name: Run Build


### PR DESCRIPTION
Configures Dependabot to check and open new PRs when new action versions are released. Also addresses the warnings by GitHub Actions in the CI.