### PR TITLE
Update MySQL driver in setup.properties.example

### DIFF
--- a/src/main/config/setup.properties.example
+++ b/src/main/config/setup.properties.example
@@ -20,8 +20,7 @@ port           = 4848
 
 # MySQL
 db.target      = mysql
-db.driver      = com.mysql.jdbc.jdbc2.optional.MysqlDataSource
-!db.driver      = mysql-connector-java-5.1.30-bin.jar_com.mysql.jdbc.Driver_5_1
+db.driver      = com.mysql.cj.jdbc.MysqlDataSource
 db.url         = jdbc:mysql://localhost:3306/authn_db
 db.username    = icat
 db.password    = secret


### PR DESCRIPTION
This is the same issue as icatproject/icat.server#311:

The MySQL section in the `setup.properties.example` file is outdated. The class `com.mysql.jdbc.jdbc2.optional.MysqlDataSource` does not exist any more in recent versions of `mysql-connector-java`. The driver needs to be updated to `com.mysql.cj.jdbc.MysqlDataSource`.

I don't know exactly at which version of `mysql-connector-java` this change has been made. But I believe, it's a while ago and at least any version that supports Java 11 requires the new class. So it should be safe to update that in the example file unconditionally.