### PR TITLE
Update docs

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2012-2015 The ICAT Collaboration
+Copyright 2012-2024 The ICAT Collaboration
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 General installation instructions are at http://www.icatproject.org/installation/component
 
-Specific installation instructions are at http://www.icatproject.org/mvn/site/authn/db/${project.version}/installation.html
+Specific installation instructions are at https://repo.icatproject.org/site/authn/db/3.0.0/installation.html
 
-All documentation on authn_db may be found at http://www.icatproject.org/mvn/site/authn/db/${project.version}
+All documentation on authn_db may be found at https://repo.icatproject.org/site/authn/db/3.0.0

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://github.com/icatproject/authn.db/workflows/CI%20Build/badge.svg?branch=master)](https://github.com/icatproject/authn.db/actions?query=workflow%3A%22CI+Build%22)
 
-General installation instructions are at http://www.icatproject.org/installation/component
+General installation instructions are at [http://www.icatproject.org/installation/component](http://www.icatproject.org/installation/component)
 
-Specific installation instructions are at https://repo.icatproject.org/site/authn/db/3.0.0/installation.html
+Specific installation instructions are at [https://repo.icatproject.org/site/authn/db/3.0.0/installation.html](https://repo.icatproject.org/site/authn/db/3.0.0/installation.html)
 
-All documentation on authn_db may be found at https://repo.icatproject.org/site/authn/db/3.0.0
+All documentation on authn_db may be found at [https://repo.icatproject.org/site/authn/db/3.0.0](https://repo.icatproject.org/site/authn/db/3.0.0)


### PR DESCRIPTION
We set up this authneticator for our ICAT a little while ago, and I noticed the links in the README were incorrect. I've changed them to point at the right place, and dropped the versioned URL thing, which brings this more in line with icat.server.

I think a few of the components have the same problem, I'm happy to go through and correct them if it'd be useful.